### PR TITLE
Added event triggered when closing popup

### DIFF
--- a/src/ol-popup.js
+++ b/src/ol-popup.js
@@ -40,6 +40,10 @@
         this.closer.addEventListener('click', function(evt) {
             that.container.style.display = 'none';
             that.closer.blur();
+            //create close event for popup
+            var event = new Event('close');
+            that.dispatchEvent(event);
+         
             evt.preventDefault();
         }, false);
 


### PR DESCRIPTION
When clicking the X in the popup an *close* event is triggered on the popup object.

It can then be used like this:
```
var popup = new ol.Overlay.Popup();
popup.addEventListener('close', function(){
    alert('close');
});
```