### PR TITLE
Added support for auto generation of type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [the examples](./examples) for usage. Styling can be done via CSS.
 
 #### Parameters
 
-*   `opt_options` **ol\_Overlay\_Options** OpenLayers Overlay options,
+*   `opt_options` **ol\_Overlay\_Options?** OpenLayers Overlay options,
     defaults to `{autoPan: {animation: {duration: 250}}}`
 
 #### show

--- a/README.md
+++ b/README.md
@@ -72,18 +72,19 @@ To use the popup with the [`ol` package](https://www.npmjs.com/package/ol) and a
         *   [Parameters](#parameters-1)
     *   [hide](#hide)
     *   [isOpened](#isopened)
+*   [](#)
 
 ### Popup
 
-**Extends ol.Overlay**
+**Extends Overlay**
 
 OpenLayers Popup Overlay.
 See [the examples](./examples) for usage. Styling can be done via CSS.
 
 #### Parameters
 
-*   `opt_options` **olx.OverlayOptions** options as defined by ol.Overlay. Defaults to
-    `{autoPan: true, autoPanAnimation: {duration: 250}}`
+*   `opt_options` **ol\_Overlay\_Options** OpenLayers Overlay options,
+    defaults to `{autoPan: {animation: {duration: 250}}}`
 
 #### show
 
@@ -91,7 +92,7 @@ Show the popup.
 
 ##### Parameters
 
-*   `coord` **ol.Coordinate** Where to anchor the popup.
+*   `coord` **ol\_coordinate\_Coordinate** Where to anchor the popup.
 *   `html` **([String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element))** String or element of HTML to display within the popup.
 
 Returns **[Popup](#popup)** The Popup instance
@@ -107,6 +108,8 @@ Returns **[Popup](#popup)** The Popup instance
 Indicates if the popup is in open state
 
 Returns **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the popup instance is open
+
+###
 
 ## Contributing
 

--- a/dist/ol-popup.d.ts
+++ b/dist/ol-popup.d.ts
@@ -1,10 +1,7 @@
 /**
 * OpenLayers Popup Overlay.
 * See [the examples](./examples) for usage. Styling can be done via CSS.
-* @constructor
 * @extends {Overlay}
-* @param {import('ol/Overlay').Options} opt_options options as defined by ol.Overlay. Defaults to
-* `{animation: {duration: 250}}`
 */
 export default class Popup extends Overlay {
     /**
@@ -20,16 +17,21 @@ export default class Popup extends Overlay {
     * @param {HTMLElement} elm
     */
     private static enableTouchScroll_;
+    /**
+     * @param {ol_Overlay_Options} [opt_options] OpenLayers Overlay options,
+     *                                         defaults to `{autoPan: {animation: {duration: 250}}}`
+     */
+    constructor(opt_options?: import("ol/Overlay").Options | undefined);
     container: HTMLDivElement;
     closer: HTMLAnchorElement;
     content: HTMLDivElement;
     /**
     * Show the popup.
-    * @param {import('ol/coordinate').Coordinate} coord Where to anchor the popup.
+    * @param {ol_coordinate_Coordinate} coord Where to anchor the popup.
     * @param {String|HTMLElement} html String or element of HTML to display within the popup.
     * @returns {Popup} The Popup instance
     */
-    show(coord: import('ol/coordinate').Coordinate, html: string | HTMLElement): Popup;
+    show(coord: import("ol/coordinate").Coordinate, html: string | HTMLElement): Popup;
     /**
     * Hide the popup.
     * @returns {Popup} The Popup instance
@@ -41,4 +43,6 @@ export default class Popup extends Overlay {
     */
     isOpened(): boolean;
 }
+export type ol_Overlay_Options = import('ol/Overlay').Options;
+export type ol_coordinate_Coordinate = import('ol/coordinate').Coordinate;
 import Overlay from 'ol/Overlay';

--- a/dist/ol-popup.d.ts
+++ b/dist/ol-popup.d.ts
@@ -1,0 +1,44 @@
+/**
+* OpenLayers Popup Overlay.
+* See [the examples](./examples) for usage. Styling can be done via CSS.
+* @constructor
+* @extends {Overlay}
+* @param {import('ol/Overlay').Options} opt_options options as defined by ol.Overlay. Defaults to
+* `{animation: {duration: 250}}`
+*/
+export default class Popup extends Overlay {
+    /**
+    * @private
+    * @desc Determine if the current browser supports touch events. Adapted from
+    * https://gist.github.com/chrismbarr/4107472
+    */
+    private static isTouchDevice_;
+    /**
+    * @private
+    * @desc Apply workaround to enable scrolling of overflowing content within an
+    * element. Adapted from https://gist.github.com/chrismbarr/4107472
+    * @param {HTMLElement} elm
+    */
+    private static enableTouchScroll_;
+    container: HTMLDivElement;
+    closer: HTMLAnchorElement;
+    content: HTMLDivElement;
+    /**
+    * Show the popup.
+    * @param {import('ol/coordinate').Coordinate} coord Where to anchor the popup.
+    * @param {String|HTMLElement} html String or element of HTML to display within the popup.
+    * @returns {Popup} The Popup instance
+    */
+    show(coord: import('ol/coordinate').Coordinate, html: string | HTMLElement): Popup;
+    /**
+    * Hide the popup.
+    * @returns {Popup} The Popup instance
+    */
+    hide(): Popup;
+    /**
+    * Indicates if the popup is in open state
+    * @returns {Boolean} Whether the popup instance is open
+    */
+    isOpened(): boolean;
+}
+import Overlay from 'ol/Overlay';

--- a/dist/ol-popup.js
+++ b/dist/ol-popup.js
@@ -9,16 +9,14 @@ Overlay = 'default' in Overlay ? Overlay['default'] : Overlay;
 /**
 * OpenLayers Popup Overlay.
 * See [the examples](./examples) for usage. Styling can be done via CSS.
-* @constructor
 * @extends {Overlay}
-* @param {import('ol/Overlay').Options} opt_options options as defined by ol.Overlay. Defaults to
-* `{animation: {duration: 250}}`
 */
 class Popup extends Overlay {
 
 
     /**
-     * @param {import('ol/Overlay').Options} opt_options
+     * @param {ol_Overlay_Options} [opt_options] OpenLayers Overlay options,
+     *                                         defaults to `{autoPan: {animation: {duration: 250}}}`
      */
     constructor(opt_options) {
 
@@ -63,7 +61,7 @@ class Popup extends Overlay {
 
     /**
     * Show the popup.
-    * @param {import('ol/coordinate').Coordinate} coord Where to anchor the popup.
+    * @param {ol_coordinate_Coordinate} coord Where to anchor the popup.
     * @param {String|HTMLElement} html String or element of HTML to display within the popup.
     * @returns {Popup} The Popup instance
     */
@@ -138,6 +136,11 @@ class Popup extends Overlay {
 if (window.ol && window.ol.Overlay) {
     window.ol.Overlay.Popup = Popup;
 }
+
+/**
+ * @typedef {import('ol/Overlay').Options} ol_Overlay_Options
+ * @typedef {import('ol/coordinate').Coordinate} ol_coordinate_Coordinate
+ */
 
 return Popup;
 

--- a/dist/ol-popup.js
+++ b/dist/ol-popup.js
@@ -10,23 +10,25 @@ Overlay = 'default' in Overlay ? Overlay['default'] : Overlay;
 * OpenLayers Popup Overlay.
 * See [the examples](./examples) for usage. Styling can be done via CSS.
 * @constructor
-* @extends {ol.Overlay}
-* @param {olx.OverlayOptions} opt_options options as defined by ol.Overlay. Defaults to
-* `{autoPan: true, autoPanAnimation: {duration: 250}}`
+* @extends {Overlay}
+* @param {import('ol/Overlay').Options} opt_options options as defined by ol.Overlay. Defaults to
+* `{animation: {duration: 250}}`
 */
 class Popup extends Overlay {
 
+
+    /**
+     * @param {import('ol/Overlay').Options} opt_options
+     */
     constructor(opt_options) {
 
         var options = opt_options || {};
 
         if (options.autoPan === undefined) {
-            options.autoPan = true;
-        }
-
-        if (options.autoPanAnimation === undefined) {
-            options.autoPanAnimation = {
-                duration: 250
+            options.autoPan = {
+                animation: {
+                    duration: 250
+                }
             };
         }
 
@@ -61,7 +63,7 @@ class Popup extends Overlay {
 
     /**
     * Show the popup.
-    * @param {ol.Coordinate} coord Where to anchor the popup.
+    * @param {import('ol/coordinate').Coordinate} coord Where to anchor the popup.
     * @param {String|HTMLElement} html String or element of HTML to display within the popup.
     * @returns {Popup} The Popup instance
     */
@@ -96,6 +98,7 @@ class Popup extends Overlay {
     * @private
     * @desc Apply workaround to enable scrolling of overflowing content within an
     * element. Adapted from https://gist.github.com/chrismbarr/4107472
+    * @param {HTMLElement} elm 
     */
     static enableTouchScroll_(elm) {
         if(Popup.isTouchDevice_()){
@@ -128,6 +131,7 @@ class Popup extends Overlay {
     }
 
 }
+
 
 // Expose Popup as ol.Overlay.Popup if using a full build of
 // OpenLayers

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "documentation": "^14.0.2",
         "rollup": "^0.41.4",
         "rollup-plugin-commonjs": "^7.0.0",
-        "rollup-plugin-node-resolve": "^2.0.0"
+        "rollup-plugin-node-resolve": "^2.0.0",
+        "typescript": "^5.1.3"
       },
       "peerDependencies": {
         "ol": ">=5.0.0"
@@ -3726,6 +3727,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unc-path-regex": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Matt Walker (http://longwayaround.org.uk)",
   "contributors": [
     "Avi Kelman <patcherton.fixesthings@gmail.com>",
-    "Sascha Englert <hello@englerts.de>
+    "Sascha Englert <hello@englerts.de>"
   ],
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "url": "https://github.com/walkermatt/ol-popup/issues"
   },
   "scripts": {
-    "build": "rollup --config rollup.config.js",
-    "doc": "documentation readme src/ol-popup.js --section=API"
+    "build": "rollup --config rollup.config.js && tsc --noEmit false --emitDeclarationOnly true",
+    "check": "tsc",
+    "doc": "documentation readme src/ol-popup.js --section=API",
+    "types": "tsc --noEmit false --emitDeclarationOnly true"
   },
   "peerDependencies": {
     "ol": ">=5.0.0"
@@ -26,6 +28,7 @@
     "rollup": "^0.41.4",
     "rollup-plugin-commonjs": "^7.0.0",
     "rollup-plugin-node-resolve": "^2.0.0",
-    "documentation": "^5.3.5"
+    "documentation": "^5.3.5",
+    "typescript": "^5.1.3"
   }
 }

--- a/src/ol-popup.js
+++ b/src/ol-popup.js
@@ -4,24 +4,26 @@ import Overlay from 'ol/Overlay';
 * OpenLayers Popup Overlay.
 * See [the examples](./examples) for usage. Styling can be done via CSS.
 * @constructor
-* @extends {ol.Overlay}
-* @param {olx.OverlayOptions} opt_options options as defined by ol.Overlay. Defaults to
-* `{autoPan: true, autoPanAnimation: {duration: 250}}`
+* @extends {Overlay}
+* @param {import('ol/Overlay').Options} opt_options options as defined by ol.Overlay. Defaults to
+* `{animation: {duration: 250}}`
 */
 export default class Popup extends Overlay {
 
+
+    /**
+     * @param {import('ol/Overlay').Options} opt_options
+     */
     constructor(opt_options) {
 
         var options = opt_options || {};
 
         if (options.autoPan === undefined) {
-            options.autoPan = true;
-        }
-
-        if (options.autoPanAnimation === undefined) {
-            options.autoPanAnimation = {
-                duration: 250
-            };
+            options.autoPan = {
+                animation: {
+                    duration: 250
+                }
+            }
         }
 
         var element = document.createElement('div');
@@ -55,7 +57,7 @@ export default class Popup extends Overlay {
 
     /**
     * Show the popup.
-    * @param {ol.Coordinate} coord Where to anchor the popup.
+    * @param {import('ol/coordinate').Coordinate} coord Where to anchor the popup.
     * @param {String|HTMLElement} html String or element of HTML to display within the popup.
     * @returns {Popup} The Popup instance
     */
@@ -90,6 +92,7 @@ export default class Popup extends Overlay {
     * @private
     * @desc Apply workaround to enable scrolling of overflowing content within an
     * element. Adapted from https://gist.github.com/chrismbarr/4107472
+    * @param {HTMLElement} elm 
     */
     static enableTouchScroll_(elm) {
         if(Popup.isTouchDevice_()){
@@ -122,6 +125,7 @@ export default class Popup extends Overlay {
     }
 
 }
+
 
 // Expose Popup as ol.Overlay.Popup if using a full build of
 // OpenLayers

--- a/src/ol-popup.js
+++ b/src/ol-popup.js
@@ -9,7 +9,7 @@ export default class Popup extends Overlay {
 
 
     /**
-     * @param {ol_Overlay_Options} opt_options OpenLayers Overlay options,
+     * @param {ol_Overlay_Options} [opt_options] OpenLayers Overlay options,
      *                                         defaults to `{autoPan: {animation: {duration: 250}}}`
      */
     constructor(opt_options) {

--- a/src/ol-popup.js
+++ b/src/ol-popup.js
@@ -3,16 +3,14 @@ import Overlay from 'ol/Overlay';
 /**
 * OpenLayers Popup Overlay.
 * See [the examples](./examples) for usage. Styling can be done via CSS.
-* @constructor
 * @extends {Overlay}
-* @param {import('ol/Overlay').Options} opt_options options as defined by ol.Overlay. Defaults to
-* `{animation: {duration: 250}}`
 */
 export default class Popup extends Overlay {
 
 
     /**
-     * @param {import('ol/Overlay').Options} opt_options
+     * @param {ol_Overlay_Options} opt_options OpenLayers Overlay options,
+     *                                         defaults to `{autoPan: {animation: {duration: 250}}}`
      */
     constructor(opt_options) {
 
@@ -57,7 +55,7 @@ export default class Popup extends Overlay {
 
     /**
     * Show the popup.
-    * @param {import('ol/coordinate').Coordinate} coord Where to anchor the popup.
+    * @param {ol_coordinate_Coordinate} coord Where to anchor the popup.
     * @param {String|HTMLElement} html String or element of HTML to display within the popup.
     * @returns {Popup} The Popup instance
     */
@@ -132,3 +130,8 @@ export default class Popup extends Overlay {
 if (window.ol && window.ol.Overlay) {
     window.ol.Overlay.Popup = Popup;
 }
+
+/**
+ * @typedef {import('ol/Overlay').Options} ol_Overlay_Options
+ * @typedef {import('ol/coordinate').Coordinate} ol_coordinate_Coordinate
+ */

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -1,0 +1,10 @@
+import Overlay from "ol/Overlay";
+import Popup from "./ol-popup";
+
+declare global {
+    interface Window {
+        ol: {
+            Overlay: Overlay & {Popup: typeof Popup}
+        };
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+      "lib": ["es2020", "DOM"],
+      "moduleResolution": "node",
+      "module": "esnext",
+      "resolveJsonModule": true,
+      "allowJs": true,
+      "checkJs": true,
+      "noEmit": true,
+      "strict": true,
+      "declaration": true,
+      "declarationDir": "dist"
+    },
+    "include": ["src/**/*.js", "src/**/*.d.ts"],
+    "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Hello everyone,
I added support for generating a Typescript `*.d.ts` file from the current JS code. Basically, I followed [this guide](https://gils-blog.tayar.org/posts/jsdoc-typings-all-the-benefits-none-of-the-drawbacks/) on how to get basically all TS features in plain JS.

I had to do a small rewrite in the constructor, as there is no `autoPanDuration` property in the constructor parameters of `ol.Overlay` (anymore?). A quick check from my side showed no difference in behavior, but as I have just started using `ol-popup` and `ol` in general, I might have missed something, so please feel free to do so as well.